### PR TITLE
Fix secondary windows decoration

### DIFF
--- a/rootfs/etc/openbox/main-window-selection.xml
+++ b/rootfs/etc/openbox/main-window-selection.xml
@@ -1,2 +1,3 @@
 <Type>normal</Type>
 <Name>Mail</Name>
+<Role>3pane</Role>


### PR DESCRIPTION
I've noticed that the application was not functioning properly when secondary windows were open (especially with the Send Later plugin).

This patch proposes a more precise targeting of Thunderbird's main window.